### PR TITLE
Update dropwizard-parent-pom to use the new style log_format label.

### DIFF
--- a/dropwizard-parent-pom/pom.xml
+++ b/dropwizard-parent-pom/pom.xml
@@ -62,7 +62,7 @@
                 <image>
                   <build>
                     <labels>
-                      <com.mainstreethub.log-format>dropwizard</com.mainstreethub.log-format>
+                      <log_format>dropwizard</log_format>
                     </labels>
                     <ports>
                       <port>8080</port>


### PR DESCRIPTION
See mainstreethub/ops#1457 for the corresponding change to the logstash configuration.

This code in this PR shouldn't be released until mainstreethub/ops#1457 is merged and deployed.