### PR TITLE
Update dropwizard-parent-pom to use latest ecs-parent-pom

### DIFF
--- a/dropwizard-parent-pom/pom.xml
+++ b/dropwizard-parent-pom/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.mainstreethub</groupId>
     <artifactId>ecs-parent-pom</artifactId>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
   </parent>
 
   <artifactId>dropwizard-parent-pom</artifactId>
@@ -55,7 +55,7 @@
             <id>docker-image</id>
             <phase>package</phase>
             <goals>
-              <goal>build</goal>
+              <goal>build-nofork</goal>
             </goals>
             <configuration>
               <images>

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,15 @@ registry (hosted in ECR).
 fat jar that contains all of it's dependencies as well as a manifest specifying
 a main class.
 
+### Releases
+
+#### 1.1.0
+
+* Updated base image from docker.io/java to docker.io/openjdk.
+* Made base image configurable for image build.
+* Added labels to Docker image for application (app) and application version (app_version)
+* Upgraded docker-maven-plugin to version 0.18.1
+
 ## dropwizard-parent-pom
 This pom adds the ability to easily build a Dropwizard application as a Docker
 image.  The image is automatically configured to expose ports 8080 and 8081 to
@@ -23,3 +32,9 @@ the container host so that the web and admin ports can both be used.  In
 addition, the arguments to the application command are set to
 `server classpath://config.yaml`.  If necessary this can be overridden in a
 child pom.
+
+### Releases
+
+#### 1.0.2-3
+
+* Upgraded parent pom to ecs-parent-pom version 1.1.0.


### PR DESCRIPTION
Closes [INF-680](https://mainstreethub.atlassian.net/browse/INF-680)

ecs-parent-pom has been released utilize the new version in the dropwizard-parent-pom