### PR TITLE
Update docker build command

### DIFF
--- a/dropwizard-parent-pom/pom.xml
+++ b/dropwizard-parent-pom/pom.xml
@@ -63,7 +63,7 @@
               <id>docker-image</id>
               <phase>package</phase>
               <goals>
-                <goal>build-nofork</goal>
+                <goal>build</goal>
               </goals>
               <configuration>
                 <images>


### PR DESCRIPTION
As per https://github.com/fabric8io/docker-maven-plugin/blob/master/doc/changelog.md the default behavior is now to prevent forking so the `build-nofork` command has been removed.