### PR TITLE
Enable skipExtendedAuth for docker maven plugin

### DIFF
--- a/ecs-parent-pom/pom.xml
+++ b/ecs-parent-pom/pom.xml
@@ -118,6 +118,7 @@
               <configuration>
                 <skip>${skip.docker.image.push}</skip>
                 <removeAll>true</removeAll>
+                <skipExtendedAuth/>
                 <images>
                   <image>
                     <name>${docker.repository}/${docker.artifactId}:${project.version}</name>

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,9 @@ a main class.
 
 ### Releases
 
+#### 1.3.1
+* Enable `skipExtendedAuth` for `docker-maven-plugin`
+
 #### 1.3.0
 * Upgraded parent POM, `com.mainstreethub:parent-pom`, to 1.6.0
 


### PR DESCRIPTION
Since we provide our own docker credentials we do not want the built-in capability to retrieve docker credentials.